### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
       - name: Take web page screenshots
-        uses: saadmk11/comment-webpage-screenshot@main
+        uses: unsortedhashsets/comment-webpage-screenshot@main
         with:
           upload_to: github_branch
           capture_changed_html_files: no

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -30,5 +30,11 @@ jobs:
         shell: bash
         run: capture-website http://172.17.0.1:80 --output ./screenshot.png --full-page
 
+      - name: Upload screenshot
+        uses: actions/upload-artifact@latest
+        with:
+          name: dashboard-home
+          path: ./screenshot.png
+
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -18,6 +18,8 @@ jobs:
         run: docker ps
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
+      - name: "Fix issue: Error: Could not find Chromium (rev. 1069273). This can occur if either"
+        run: node node_modules/puppeteer/install.js
       - name: Take web page screenshots
         uses: saadmk11/comment-webpage-screenshot@main
         with:

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           upload_to: github_branch
           capture_changed_html_files: no
-          capture_urls: "http://172.17.0.1:8080"
+          capture_urls: "http://172.17.0.1:80"
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
       - name: Take web page screenshots
-        uses: unsortedhashsets/comment-webpage-screenshot@main
+        uses: saadmk11/comment-webpage-screenshot@main
         with:
           upload_to: github_branch
           capture_changed_html_files: no
-          capture_urls: "http://172.17.0.1:80"
+          capture_urls: "http://172.17.0.1:8080"
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -31,7 +31,7 @@ jobs:
         run: capture-website http://172.17.0.1:80 --output ./screenshot.png --full-page
 
       - name: Upload screenshot
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v3
         with:
           name: dashboard-home
           path: ./screenshot.png

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -18,13 +18,10 @@ jobs:
         run: docker ps
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
-      - name: "Fix issue: Error: Could not find Chromium (rev. 1069273). This can occur if either"
-        run: node node_modules/puppeteer/install.js
-      - name: Take web page screenshots
-        uses: saadmk11/comment-webpage-screenshot@main
+      - name: Screenshot Website
+        uses: swinton/screenshot-website@v1.x
         with:
-          upload_to: github_branch
-          capture_changed_html_files: no
-          capture_urls: "http://172.17.0.1:80"
+          source: "http://172.17.0.1:80"
+          destination: screenshot.png
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -12,17 +12,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Build the stack
         run: docker-compose -f docker-compose-test.yml up --build --detach
+
       - name: Check containers
         run: docker ps
+
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
-      - name: Take web page screenshots
-        uses: saadmk11/comment-webpage-screenshot@main
-        with:
-          upload_to: github_branch
-          capture_changed_html_files: no
-          capture_urls: "http://172.17.0.1:8080"
+
+      - name: Install capture-website-cli
+        shell: bash
+        run: npm install --global capture-website-cli
+
+      - name: Screenshot Website
+        shell: bash
+        run: capture-website http://172.17.0.1:80 --output ./screenshot.png --full-page
+
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -18,10 +18,11 @@ jobs:
         run: docker ps
       - name: Print docker-compose logs
         run: docker-compose -f docker-compose-test.yml logs
-      - name: Screenshot Website
-        uses: swinton/screenshot-website@v1.x
+      - name: Take web page screenshots
+        uses: saadmk11/comment-webpage-screenshot@main
         with:
-          source: "http://172.17.0.1:80"
-          destination: screenshot.png
+          upload_to: github_branch
+          capture_changed_html_files: no
+          capture_urls: "http://172.17.0.1:8080"
       - name: Docker-compose down
         run: docker-compose -f docker-compose-test.yml down


### PR DESCRIPTION
Capture Screenshot for "[http://172.17.0.1:80](http://172.17.0.1/)"
  Error: Could not find Chromium (rev. [10](https://github.com/unsortedhashsets/cicd_dashboard/actions/runs/3933244520/jobs/6726741819#step:7:12)69273). This can occur if either
   1. you did not perform an installation before running the script (e.g. `npm install`) or
   2. your cache path is incorrectly configured (which is: /github/home/.cache/puppeteer).
  For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
      at ChromeLauncher.resolveExecutablePath (file:///usr/lib/node_modules/capture-website-cli/node_modules/puppeteer-core/lib/esm/puppeteer/node/ProductLauncher.js:93:27)
      at ChromeLauncher.executablePath (file:///usr/lib/node_modules/capture-website-cli/node_modules/puppeteer-core/lib/esm/puppeteer/node/ChromeLauncher.js:176:25)
      at ChromeLauncher.launch (file:///usr/lib/node_modules/capture-website-cli/node_modules/puppeteer-core/lib/esm/puppeteer/node/ChromeLauncher.js:64:37)
      at async internalCaptureWebsite (file:///usr/lib/node_modules/capture-website-cli/node_modules/capture-website/index.js:[14](https://github.com/unsortedhashsets/cicd_dashboard/actions/runs/3933244520/jobs/6726741819#step:7:16)9:33)
      at async file:///usr/lib/node_modules/capture-website-cli/cli.js:289:24
  Error: Error while trying to Capture Screenshot for "http://[17](https://github.com/unsortedhashsets/cicd_dashboard/actions/runs/3933244520/jobs/6726741819#step:7:19)2.17.0.1:80". Error: b''